### PR TITLE
Update sensors.yaml - more frequent PMS update onterval

### DIFF
--- a/sensorbox/sensors.yaml
+++ b/sensorbox/sensors.yaml
@@ -163,7 +163,7 @@ sensor:
 
   - platform: pmsx003
     type: PMSX003 
-    update_interval: 120s
+    update_interval: 30s
     uart_id: uart_pms
     pm_1_0:
       name: "PMS Particulate Matter <1.0µm Concentration"


### PR DESCRIPTION
There is absolutely no need to make this one update interval so rare. 120s update interval makes it harder troubleshoot or even know it works properly in a first place - since all other sensor syncs much faster after boot. Same issue was present in Tom's code, but let's fix it now.